### PR TITLE
Neck U-joint work (for single u-joint)

### DIFF
--- a/src/HardwareFactory.py
+++ b/src/HardwareFactory.py
@@ -1,3 +1,29 @@
+#
+# Factory for the pololu and dynamixel motors.
+#
+# The factory here will create classes that take numerical motor angles
+# as input and publish the same as ROS messages for the specified topics.
+#
+# The expected format is ....
+#
+# ----------------------------------------------------------------
+# Copyright (C) 2014, 2015 Hanson Robotics
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301  USA
+
 import Utils
 import ShapekeyStore
 from ros_pololu.msg import MotorCommand

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -214,64 +214,6 @@ class Quaternion2EulerYZX(MapperBase):
     }
     self.map = funcsByAxis[args['axis'].lower()]
 
-class Quaternion2EulerYZY(MapperBase):
-# class Quaternion2EulerYZX(MapperBase):
-
-  def __init__(self, args, motor_entry):
-
-    # These functions convert a quaternion to Y-Z-Y rotations.
-    # The convention here is different than above, with X axis the line
-    # of sight, Y axis to the left, and Z upwards.
-    #  For a different rotation order, swap
-    # q.x, q.y, q.z variables and 'x', 'y', 'z' keys.
-    #
-    def why(q) :
-        # print("duuude q=", q)
-        alpha = 2.0 * math.acos(q.w)
-        # print("alpha = ", 180 *  alpha / 3.141592653)
-        sina = math.sin(0.5 * alpha)
-        cx = q.x / sina
-        cy = q.y / sina
-        cz = q.z / sina
-        bx = 180 * math.acos(cx) / 3.141592653
-        by = 180 * math.acos(cy) / 3.141592653
-        bz = 180 * math.acos(cz) / 3.141592653
-        # print("beta = ", bx, by, bz)
-
-        tx = math.atan2(
-            -2 *(q.y * q.z - q.w * q.x),
-            q.w**2 + q.y**2 - q.z**2 - q.x**2
-          )
-        ty = math.atan2(
-            -2 * (q.z * q.x - q.w * q.y),
-            q.w**2 - q.y**2 - q.z**2 + q.x**2
-          )
-        tz = math.asin(
-            2 * (q.y * q.x + q.w * q.z)
-          )
-        tx = 180 * tx / 3.14159
-        ty = 180 * ty / 3.14159
-        tz = 180 * tz / 3.14159
-        print("duude pry=", tx, ty, tz)
-        return math.atan2(
-          -2 * (q.z * q.x - q.w * q.y),
-          q.w**2 - q.y**2 - q.z**2 + q.x**2
-        )
-
-    funcsByAxis = {
-      'x': lambda q: why(q),
-      'z': lambda q:
-          math.asin(
-            2 * (q.y * q.x + q.w * q.z)
-          ),
-      'y': lambda q:
-          math.atan2(
-            -2 *(q.y * q.z - q.w * q.x),
-            q.w**2 + q.y**2 - q.z**2 - q.x**2
-          )
-    }
-    self.map = funcsByAxis[args['axis'].lower()]
-
 # --------------------------------------------------------------
 class Quaternion2Neck(MapperBase):
 
@@ -370,7 +312,6 @@ _mapper_classes = {
   "linear": Linear,
   "weightedsum": WeightedSum,
   "quaternion2euler": Quaternion2EulerYZX,
-  "quaternion2YZY": Quaternion2EulerYZY,
   "quaternion2neck": Quaternion2Neck
 }
 

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -171,8 +171,8 @@ class WeightedSum(MapperBase):
 
 # --------------------------------------------------------------
 
-# class Quaternion2EulerYZX(MapperBase):
-class Quaternion2EulerYZY(MapperBase):
+class Quaternion2EulerYZX(MapperBase):
+# class Quaternion2EulerYZY(MapperBase):
 
   def __init__(self, args, motor_entry):
 
@@ -205,8 +205,8 @@ class Quaternion2EulerYZY(MapperBase):
     }
     self.map = funcsByAxis[args['axis'].lower()]
 
-# class Quaternion2EulerYZY(MapperBase):
-class Quaternion2EulerYZX(MapperBase):
+class Quaternion2EulerYZY(MapperBase):
+# class Quaternion2EulerYZX(MapperBase):
 
   def __init__(self, args, motor_entry):
 
@@ -228,7 +228,7 @@ class Quaternion2EulerYZX(MapperBase):
         by = 180 * math.acos(cy) / 3.141592653
         bz = 180 * math.acos(cz) / 3.141592653
         # print("beta = ", bx, by, bz)
- 
+
         tx = math.atan2(
             -2 *(q.y * q.z - q.w * q.x),
             q.w**2 + q.y**2 - q.z**2 - q.x**2
@@ -248,7 +248,7 @@ class Quaternion2EulerYZX(MapperBase):
           -2 * (q.z * q.x - q.w * q.y),
           q.w**2 - q.y**2 - q.z**2 + q.x**2
         )
-        
+
     funcsByAxis = {
       'x': lambda q: why(q),
       'z': lambda q:

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -215,6 +215,15 @@ class Quaternion2EulerYZX(MapperBase):
     self.map = funcsByAxis[args['axis'].lower()]
 
 # --------------------------------------------------------------
+#
+# This class accepts a single quaternion from blender, and converts
+# it to motor angles for a single u-joint; by default, the upper-neck
+# u-joint.  The blender quaternion coordinate system is described
+# below.  The motor angles are computed using geometry appropriate
+# for the Han neck mechanism; note that the Eva mechanism has different
+# dimensions; these dimensions are currently hard-coded in
+# NeckKinematics.py
+#
 class Quaternion2Neck(MapperBase):
 
   def __init__(self, args, motor_entry):
@@ -267,7 +276,7 @@ class Quaternion2Neck(MapperBase):
             - q_1 * q_3 + q_0 * q_2
           )
         #
-        # print "Euler phi theta psi", self.phi, self.theta, self.psi, self.phi + self.psi 
+        # print "Euler phi theta psi", self.phi, self.theta, self.psi, self.phi + self.psi
 
     # Returns the upper-neck left motor position, in radians
     def get_upper_left(q) :

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -287,30 +287,40 @@ class Quaternion2Neck(MapperBase):
     # x-axis == body-left (Eva's left side)
     # y-axis == straight ahead
     # z-axis == down
-
-
-    # The formulas below are taken from Wikipedia, with the convention
-    # that     q_0 = q.w      q_1 = q.x     q_2 = q.y     q_3 = q.z
-    # https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
-    # and that phi == roll == rotate about body X
-    #          theta == pitch == rot about body Y
-    #          psi == yaw ==  rotate about body Z
-    # with X == foreward    Y == to right    and Z == down
     #
-    # XXX however, the above is NOT the correct interpretation for
-    # quaternions that blender is giving to us. In the blender system,
-    # phi seems to be the pitch... and theta is always approx zero ...
+    # We want to convert to Euler ngles with the following coordinates:
+    # x-axis == straight ahead
+    # y-axis == body-left
+    # z-axis == up
+    #
+    # The formulas below are taken from Wikipedia, but in modified form.
+    # We use the sphere-angle coordinates:
+    # theta == angle w.r.t. z-axis
+    # phi == azimuthal angle, from x axis
+    # psi == body roll
+    # that is,
+    # Rot = Rot(z, phi) Rot (y, theta) Rot (z, psi)
+    #
+    # https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+    #
+    # To reconcile what blender is giving us, with the desired coordinates,
+    # above, we make the following substitutions
+    q_0 = q.w
+    q_1 = q.y
+    q_2 = q.x
+    q_3 = -q.z
+    #
     def quat_to_euler(q) :
         self.phi = math.atan2(
-            2 * (q.w * q.x + q.y * q.z),
-            1 - 2 * (q.x**2 + q.y**2)
+            (-q_0 * q_1 + q_2 * q_3),
+            (q_0 * q_2 + q_1 * q_3)
           )
-        self.theta = math.asin(
-            2 * (q.w * q.y - q.x * q.z)
+        self.theta = math.acos(
+            q_0 * q_0 - q_1 * q_1 - q_2 * q_2 + q_3 * q_3
           )
-        self.psi = math.atan2(
-            2 * (q.w * q.z + q.x * q.y),
-            1 - 2 * (q.y**2 + q.z**2)
+        self.psi = - math.atan2(
+            q_0 * q_1 + q_2 * q_3,
+            q_1 * q_3 - q_0 * q_2
           )
         # print "duuuuude phi theta psi", self.phi, self.theta, self.psi
 

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -18,6 +18,7 @@
 # 02110-1301  USA
 
 import math
+import NeckKinematics
 
 class MapperBase:
   """
@@ -268,18 +269,43 @@ class Quaternion2Neck(MapperBase):
 
   def __init__(self, args, motor_entry):
 
-    funcs = {
-      'ul': lambda q:
-            0.42,
-      'z': lambda q:
-          math.asin(
-            2 * (q.y * q.x + q.w * q.z)
-          ),
-      'x': lambda q:
-          math.atan2(
-            -2 *(q.y * q.z - q.w * q.x),
-            q.w**2 + q.y**2 - q.z**2 - q.x**2
+    self.hijoint = NeckKinematics.upper_neck()
+    self.lojoint = NeckKinematics.lower_neck()
+    self.phi = 0.0
+    self.theta = 0.0
+    self.psi = 0.0
+
+
+    def quat_to_euler(q) :
+        self.phi = math.atan2(
+            2 * (q.w * q.x + q.y * q.z),
+            1 - 2 * (q.x**2 + q.y**2)
           )
+        self.theta = math.asin(
+            2 * (q.w * q.y - q.x * q.z)
+          )
+        self.psi = math.atan2(
+            2 * (q.w * q.z + q.x * q.y),
+            1 - 2 * (q.y**2 + q.z**2)
+          )
+        print "duuuuude phi theta psi", self.phi, self.theta, self.psi
+
+    def get_upper_left(q) :
+        quat_to_euler(q)
+        self.hijoint.inverse_kinematics(self.theta, self.phi)
+        print "duude left mot", self.hijoint.theta_l
+        return self.hijoint.theta_l
+
+    def get_upper_right(q) :
+        quat_to_euler(q)
+        self.hijoint.inverse_kinematics(self.theta, self.phi)
+        print "duude right mot", self.hijoint.theta_r
+        return self.hijoint.theta_r
+
+
+    funcs = {
+      'ul': lambda q: get_upper_left(q),
+      'ur': lambda q: get_upper_right(q)
     }
     self.map = funcs[args['axis'].lower()]
 

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -264,12 +264,32 @@ class Quaternion2EulerYZY(MapperBase):
     self.map = funcsByAxis[args['axis'].lower()]
 
 # --------------------------------------------------------------
+class Quaternion2Neck(MapperBase):
+
+  def __init__(self, args, motor_entry):
+
+    funcs = {
+      'ul': lambda q:
+            0.42,
+      'z': lambda q:
+          math.asin(
+            2 * (q.y * q.x + q.w * q.z)
+          ),
+      'x': lambda q:
+          math.atan2(
+            -2 *(q.y * q.z - q.w * q.x),
+            q.w**2 + q.y**2 - q.z**2 - q.x**2
+          )
+    }
+    self.map = funcs[args['axis'].lower()]
+
 
 _mapper_classes = {
   "linear": Linear,
   "weightedsum": WeightedSum,
   "quaternion2euler": Quaternion2EulerYZX,
-  "quaternion2YZY": Quaternion2EulerYZY
+  "quaternion2YZY": Quaternion2EulerYZY,
+  "quaternion2neck": Quaternion2Neck
 }
 
 def build(yamlobj, motor_entry):

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -327,6 +327,7 @@ class Quaternion2Neck(MapperBase):
         #
         # print "Euler phi theta psi", self.phi, self.theta, self.psi, self.phi + self.psi 
 
+    # Returns the upper-neck left motor position, in radians
     def get_upper_left(q) :
         # print "Quaternions:", q.w, q.x, q.y, q.z
         # e = q.x*q.x + q.y*q.y + q.z*q.z
@@ -339,20 +340,23 @@ class Quaternion2Neck(MapperBase):
         # print "alpha, axis:", alpha, nex, ney, nez
         quat_to_euler(q)
         self.hijoint.inverse_kinematics(self.theta, self.phi)
-        print "duude left right mot", self.hijoint.theta_l, self.hijoint.theta_r
+        print "Motors: left right yaw", self.hijoint.theta_l, self.hijoint.theta_r, get_yaw(q)
         return self.hijoint.theta_l
 
+    # Returns the upper-neck right motor position, in radians
     def get_upper_right(q) :
         quat_to_euler(q)
         self.hijoint.inverse_kinematics(self.theta, self.phi)
-        print "duude right mot", self.hijoint.theta_r
         return self.hijoint.theta_r
 
-    # Yaw (spin about neck-skull) axis appears to be psi in the
-    # canonical quat-to-euler transform...
+    # Yaw (spin about neck-skull) axis, in radians, right hand rule.
     def get_yaw(q) :
         quat_to_euler(q)
-        return self.psi
+        # glurgle this is not really right ...
+        yaw = self.psi + self.phi
+        if 3.1415926 < yaw:
+            yaw -= 2 * 3.14159265358979
+        return yaw
 
     funcs = {
       'upleft': lambda q: get_upper_left(q),

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -283,6 +283,11 @@ class Quaternion2Neck(MapperBase):
     self.theta = 0.0
     self.psi = 0.0
 
+    # Blender provides us with quaternions in the coordinate frame:
+    # x-axis == body-left (Eva's left side)
+    # y-axis == straight ahead
+    # z-axis == down
+
 
     # The formulas below are taken from Wikipedia, with the convention
     # that     q_0 = q.w      q_1 = q.x     q_2 = q.y     q_3 = q.z
@@ -307,12 +312,21 @@ class Quaternion2Neck(MapperBase):
             2 * (q.w * q.z + q.x * q.y),
             1 - 2 * (q.y**2 + q.z**2)
           )
-        print "duuuuude phi theta psi", self.phi, self.theta, self.psi
+        # print "duuuuude phi theta psi", self.phi, self.theta, self.psi
 
     def get_upper_left(q) :
+        print "duude quat", q.w, q.x, q.y, q.z
+        e = q.x*q.x + q.y*q.y + q.z*q.z
+        n = q.w*q.w + e
+        e = math.sqrt(e)
+        alpha = 2 * math.asin (e)
+        nex = q.x / e
+        ney = q.y / e
+        nez = q.z / e
+        print "duuu al=", alpha, nex, ney, nez
         quat_to_euler(q)
         self.hijoint.inverse_kinematics(self.theta, self.phi)
-        print "duude left right mot", self.hijoint.theta_l, self.hijoint.theta_r
+        # print "duude left right mot", self.hijoint.theta_l, self.hijoint.theta_r
         return self.hijoint.theta_l
 
     def get_upper_right(q) :

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -185,19 +185,22 @@ class Quaternion2EulerYZX(MapperBase):
     #
     # Properly speaking, these are not Euler angles, but Tate-Bryan angles.
     #
-    # Note: Kudos to anyone who manages to put this swapping mechanism into code,
-    # which also builds functions to compute only one of the rotations like
-    # below. (it's harder than it looks)
+    # Note: Kudos to anyone who manages to put this swapping mechanism into
+    # code, which also builds functions to compute only one of the rotations
+    # like below. (it's harder than it looks)
+    def tate_z(q) :
+        z = math.asin(2 * (q.y * q.x + q.w * q.z))
+        return z
+
     funcsByAxis = {
       'y': lambda q:
           math.atan2(
             -2 * (q.z * q.x - q.w * q.y),
             q.w**2 - q.y**2 - q.z**2 + q.x**2
           ),
-      'z': lambda q:
-          math.asin(
-            2 * (q.y * q.x + q.w * q.z)
-          ),
+      'z': lambda q :
+          tate_z(q),
+
       'x': lambda q:
           math.atan2(
             -2 *(q.y * q.z - q.w * q.x),
@@ -293,7 +296,7 @@ class Quaternion2Neck(MapperBase):
     def get_upper_left(q) :
         quat_to_euler(q)
         self.hijoint.inverse_kinematics(self.theta, self.phi)
-        print "duude left mot", self.hijoint.theta_l
+        # print "duude left mot", self.hijoint.theta_l
         return self.hijoint.theta_l
 
     def get_upper_right(q) :
@@ -302,10 +305,16 @@ class Quaternion2Neck(MapperBase):
         print "duude right mot", self.hijoint.theta_r
         return self.hijoint.theta_r
 
+    # Yaw (spin about neck-skull) axis appears to be psi in the
+    # canonical quat-to-euler transform...
+    def get_yaw(q) :
+        quat_to_euler(q)
+        return self.psi
 
     funcs = {
       'ul': lambda q: get_upper_left(q),
       'ur': lambda q: get_upper_right(q)
+      'yaw': lambda q: get_yaw(q)
     }
     self.map = funcs[args['axis'].lower()]
 

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -303,14 +303,16 @@ class Quaternion2Neck(MapperBase):
     #
     # https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
     #
-    # To reconcile what blender is giving us, with the desired coordinates,
-    # above, we make the following substitutions
-    q_0 = q.w
-    q_1 = q.y
-    q_2 = q.x
-    q_3 = -q.z
-    #
+    # Status: 1 July 2015: this now works exactly as expected! Woot!
     def quat_to_euler(q) :
+        # To reconcile what blender is giving us, with the desired
+        # coordinates, above, we make the following substitutions.
+        #
+        q_0 = q.w
+        q_1 = q.y
+        q_2 = q.x
+        q_3 = -q.z
+        #
         self.phi = math.atan2(
             (-q_0 * q_1 + q_2 * q_3),
             (q_0 * q_2 + q_1 * q_3)
@@ -318,25 +320,26 @@ class Quaternion2Neck(MapperBase):
         self.theta = math.acos(
             q_0 * q_0 - q_1 * q_1 - q_2 * q_2 + q_3 * q_3
           )
-        self.psi = - math.atan2(
+        self.psi = math.atan2(
             q_0 * q_1 + q_2 * q_3,
-            q_1 * q_3 - q_0 * q_2
+            - q_1 * q_3 + q_0 * q_2
           )
-        # print "duuuuude phi theta psi", self.phi, self.theta, self.psi
+        #
+        # print "Euler phi theta psi", self.phi, self.theta, self.psi, self.phi + self.psi 
 
     def get_upper_left(q) :
-        print "duude quat", q.w, q.x, q.y, q.z
-        e = q.x*q.x + q.y*q.y + q.z*q.z
-        n = q.w*q.w + e
-        e = math.sqrt(e)
-        alpha = 2 * math.asin (e)
-        nex = q.x / e
-        ney = q.y / e
-        nez = q.z / e
-        print "duuu al=", alpha, nex, ney, nez
+        # print "Quaternions:", q.w, q.x, q.y, q.z
+        # e = q.x*q.x + q.y*q.y + q.z*q.z
+        # n = q.w*q.w + e
+        # e = math.sqrt(e)
+        # alpha = 2 * math.asin (e)
+        # nex = q.x / e
+        # ney = q.y / e
+        # nez = q.z / e
+        # print "alpha, axis:", alpha, nex, ney, nez
         quat_to_euler(q)
         self.hijoint.inverse_kinematics(self.theta, self.phi)
-        # print "duude left right mot", self.hijoint.theta_l, self.hijoint.theta_r
+        print "duude left right mot", self.hijoint.theta_l, self.hijoint.theta_r
         return self.hijoint.theta_l
 
     def get_upper_right(q) :

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -291,6 +291,10 @@ class Quaternion2Neck(MapperBase):
     #          theta == pitch == rot about body Y
     #          psi == yaw ==  rotate about body Z
     # with X == foreward    Y == to right    and Z == down
+    #
+    # XXX however, the above is NOT the correct interpretation for
+    # quaternions that blender is giving to us. In the blender system,
+    # phi seems to be the pitch... and theta is always approx zero ...
     def quat_to_euler(q) :
         self.phi = math.atan2(
             2 * (q.w * q.x + q.y * q.z),

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -355,8 +355,8 @@ class Quaternion2Neck(MapperBase):
         return self.psi
 
     funcs = {
-      'ul': lambda q: get_upper_left(q),
-      'ur': lambda q: get_upper_right(q),
+      'upleft': lambda q: get_upper_left(q),
+      'upright': lambda q: get_upper_right(q),
       'yaw': lambda q: get_yaw(q)
     }
     self.map = funcs[args['axis'].lower()]

--- a/src/MapperFactory.py
+++ b/src/MapperFactory.py
@@ -173,7 +173,6 @@ class WeightedSum(MapperBase):
 # --------------------------------------------------------------
 
 class Quaternion2EulerYZX(MapperBase):
-# class Quaternion2EulerYZY(MapperBase):
 
   def __init__(self, args, motor_entry):
 
@@ -192,20 +191,26 @@ class Quaternion2EulerYZX(MapperBase):
         z = math.asin(2 * (q.y * q.x + q.w * q.z))
         return z
 
-    funcsByAxis = {
-      'y': lambda q:
-          math.atan2(
+    def tate_y(q) :
+        y = math.atan2(
             -2 * (q.z * q.x - q.w * q.y),
             q.w**2 - q.y**2 - q.z**2 + q.x**2
-          ),
-      'z': lambda q :
-          tate_z(q),
+          )
+        # print "tate y=", y
+        return y
 
-      'x': lambda q:
-          math.atan2(
+    def tate_x(q) :
+        x = math.atan2(
             -2 *(q.y * q.z - q.w * q.x),
             q.w**2 + q.y**2 - q.z**2 - q.x**2
           )
+        # print "tate x=", x
+        return x
+
+    funcsByAxis = {
+      'y': lambda q : tate_y(q),
+      'z': lambda q : tate_z(q),
+      'x': lambda q : tate_x(q)
     }
     self.map = funcsByAxis[args['axis'].lower()]
 
@@ -279,6 +284,13 @@ class Quaternion2Neck(MapperBase):
     self.psi = 0.0
 
 
+    # The formulas below are taken from Wikipedia, with the convention
+    # that     q_0 = q.w      q_1 = q.x     q_2 = q.y     q_3 = q.z
+    # https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+    # and that phi == roll == rotate about body X
+    #          theta == pitch == rot about body Y
+    #          psi == yaw ==  rotate about body Z
+    # with X == foreward    Y == to right    and Z == down
     def quat_to_euler(q) :
         self.phi = math.atan2(
             2 * (q.w * q.x + q.y * q.z),
@@ -296,7 +308,7 @@ class Quaternion2Neck(MapperBase):
     def get_upper_left(q) :
         quat_to_euler(q)
         self.hijoint.inverse_kinematics(self.theta, self.phi)
-        # print "duude left mot", self.hijoint.theta_l
+        print "duude left right mot", self.hijoint.theta_l, self.hijoint.theta_r
         return self.hijoint.theta_l
 
     def get_upper_right(q) :
@@ -313,7 +325,7 @@ class Quaternion2Neck(MapperBase):
 
     funcs = {
       'ul': lambda q: get_upper_left(q),
-      'ur': lambda q: get_upper_right(q)
+      'ur': lambda q: get_upper_right(q),
       'yaw': lambda q: get_yaw(q)
     }
     self.map = funcs[args['axis'].lower()]

--- a/src/NeckKinematics.py
+++ b/src/NeckKinematics.py
@@ -29,7 +29,7 @@ def quad_trig(alpha, beta, gamma, sign):
 
 # Newtonian interpolation. Finds the zero of function func.
 # Assumes that there is one unique zero.  Assumes that func(pi/2)
-# is of oppsite sign from func(-pi/2).  Throws an exception if
+# is of opposite sign from func(-pi/2).  Throws an exception if
 # there are no solutions. In the context of the neck linkage, this
 # means that a neck position was requested that the mechanical linkage
 # simply cannot get to; even at full extension, the neck cannot be moved
@@ -60,7 +60,7 @@ def newton(func):
 # Inverse kinematics solver for the Eva/Han neck linkage mechanism.
 # Given desired sphere angles theta, phi for the neck U-joint
 # orientation, the inverse_kinematics(theta, phi) will compute the
-# motor angles to achive that position.  The two motor angles will
+# motor angles to achieve that position.  The two motor angles will
 # be set in self.theta_l and self.theta_r i.e. the left and right
 # motors.  Rotation follows the right-hand-rule.  See the accompanying
 # documentation in PDF or LyX format to see the drawings that these

--- a/src/NeckKinematics.py
+++ b/src/NeckKinematics.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 #
 # Double U-joint neck inverse kinematics.
 # Copyright (c) 2015 Hanson Robotics
@@ -31,7 +30,7 @@ def quad_trig(alpha, beta, gamma, sign):
 # Newtonian interpolation. Finds the zero of function func.
 # Assumes that there is one unique zero.  Assumes that func(pi/2)
 # is of oppsite sign from func(-pi/2).  Throws an exception if
-# there are no solutions. In the context of the eck linkage, this
+# there are no solutions. In the context of the neck linkage, this
 # means that a neck position was requested that the mechanical linkage
 # simply cannot get to; even at full extension, the neck cannot be moved
 # to there.
@@ -308,40 +307,3 @@ class upper_neck(neck_linkage):
 		# Motor neutral position
 		self.theta_r = 0.0
 		self.theta_l = 0.0
-
-def main():
-
-	if len(sys.argv) < 3:
-		print ("Usage: neck-kine <theta> <phi>")
-		return 1
-
-	theta = float(sys.argv[1])
-	phi = float(sys.argv[2])
-
-	lon = lower_neck()
-	upn = upper_neck()
-	lon.inverse_kinematics(theta, phi)
-	upn.inverse_kinematics(theta, phi)
-	print ("Input theta=", theta, " phi=", phi)
-	print ("Lower Motor angles", lon.theta_l, lon.theta_r)
-	print ("Upper motor angles", upn.theta_l, upn.theta_r)
-
-
-	thetas = [0.01*i for i in range(1,53)]
-	phis = [0.1*i for i in range(-15,15)]
-	for theta in thetas :
-		for phi in phis :
-			try:
-				lon.inverse_kinematics(theta, phi)
-			except OverflowError:
-				print ("Lower jam at theta=", theta, phi)
-
-			try:
-				upn.inverse_kinematics(theta, phi)
-			except OverflowError:
-				print ("Upper jam at theta=", theta, phi)
-
-#			# print ("Input theta=", theta, " phi=", phi)
-#			# print ("Motor angles", lon.theta_l, lon.theta_r)
-
-main()

--- a/src/neck-kine.py
+++ b/src/neck-kine.py
@@ -1,0 +1,347 @@
+#! /usr/bin/env python3
+#
+# Double U-joint neck inverse kinematics.
+# Copyright (c) 2015 Hanson Robotics
+#
+# Linas Vepstas January 2015
+#
+from math import sin, cos, sqrt, atan2, asin
+import sys
+
+# Distance
+def dist(x, y, z):
+	return sqrt(x*x + y*y + z*z)
+
+# Quadratic trig equation solver. Returns the two roots of the equation
+# alpha * sin(theta) + beta * cos(theta) + gama = 0
+# The above can be thought of as a quadratic equation in sin(theta)
+# and so can be solved as an ordinary quadratic. Finally, return
+# arcsin(theta) as the angle that solves the eqn.
+def quad_trig(alpha, beta, gamma, sign):
+	asq = alpha * alpha
+	bsq = beta * beta
+	csq = gamma * gamma
+	det = asq * csq + (bsq + asq) * (bsq - csq)
+	if det < 0.0:
+		raise OverflowError("Linkage jamming!")
+	det = sqrt(det)
+	sinth = (- alpha * gamma + sign * det) / (asq + bsq)
+	return asin(sinth)
+
+# Newtonian interpolation. Finds the zero of function func.
+# Assumes that there is one unique zero.  Assumes that func(pi/2)
+# is of oppsite sign from func(-pi/2).  Throws an exception if
+# there are no solutions. In the context of the eck linkage, this
+# means that a neck position was requested that the mechanical linkage
+# simply cannot get to; even at full extension, the neck cannot be moved
+# to there.
+def newton(func):
+	# Newton's method
+	ta = -3.1415 * 0.5
+	tb = 3.1415 * 0.5
+	da = func(ta)
+	db = func(tb)
+
+	if 0.0 <= da*db :
+		raise OverflowError("Linkage jamming!")
+
+	while True:
+		islo = (tb - ta) / (db - da)
+		tm = ta - da * islo
+		dm = func(tm)
+		if abs(dm) < 10.e-14:
+			return tm
+		if 0.0 <= dm*da:
+			da = dm
+			ta = tm
+		else:
+			db = dm
+			tb = tm
+
+# Inverse kinematics solver for the Eva/Han neck linkage mechanism.
+# Given desired sphere angles theta, phi for the neck U-joint
+# orientation, the inverse_kinematics(theta, phi) will compute the
+# motor angles to achive that position.  The two motor angles will
+# be set in self.theta_l and self.theta_r i.e. the left and right
+# motors.  Rotation follows the right-hand-rule.  See the accompanying
+# documentation in PDF or LyX format to see the drawings that these
+# dimensions and angles refer to.
+class neck_linkage:
+
+	# Initialization. None.  Must be duck-typed correctly.
+	def __init__(self):
+		pass
+
+	# Return the distance between points G and F
+	# More precisely, given a motor angle theta_r, compute the
+	# distance between motor arm joint G and the fixed location of F,
+	# and compare this to the desired distance L_FG
+	def rmoto(self, theta_r) :
+		gx = self.hx
+		gy = self.hy + self.lgh * cos(theta_r)
+		gz = self.hz + self.lgh * sin(theta_r)
+
+		gx -= self.fx
+		gy -= self.fy
+		gz -= self.fz
+
+		delta = self.lfg - dist(gx, gy, gz)
+		return delta
+
+	# Return the distance between points C and D
+	# More precisely, given a motor angle theta_l, compute the
+	# distance between motor arm joint D and the fixed location of C,
+	# and compare this to the desired distance L_CD
+	def lmoto(self, theta_l) :
+		dx = self.ex
+		dy = self.ey - self.lde * cos(theta_l)
+		dz = self.ez - self.lde * sin(theta_l)
+
+		dx -= self.cx
+		dy -= self.cy
+		dz -= self.cz
+
+		return self.lcd - dist(dx, dy, dz)
+
+	# Compute the left-hand motor angle, given the desired location for
+	# point C.  That is, this assumes that self.cx, cy, cz have been set
+	# up to the desired location. Returns the motor angle that provides
+	# that location.
+	def langle(self) :
+		alpha = self.cz - self.ez
+		beta = self.cy - self.ey
+		gamma = self.cx - self.ex
+		lce = dist(alpha, beta, gamma)
+		lcesq = lce * lce
+		ldesq = self.lde * self.lde
+		lcdsq = self.lcd * self.lcd
+		gamma = - 0.5 * (lcdsq - ldesq - lcesq) / self.lde
+
+		return quad_trig(alpha, beta, gamma, 1)
+
+	# Compute the right-hand motor angle, given the desired location for
+	# point F.  That is, this assumes that self.fx, fy, fz have been set
+	# up to the desired location. Returns the motor angle that provides
+	# that location.
+	def rangle(self) :
+		alpha = self.fz - self.hz
+		beta = self.fy - self.hy
+		gamma = self.fx - self.hx
+		lfh = dist(alpha, beta, gamma)
+		lfhsq = lfh * lfh
+		lghsq = self.lgh * self.lgh
+		lfgsq = self.lfg * self.lfg
+		gamma = - 0.5 * (lfgsq - lghsq - lfhsq) / self.lgh
+
+		return quad_trig(-alpha, beta, gamma, -1)
+
+	# Solve the inverse kinematics problem for the lower neck motors.
+	# Given spherical angles theta, phi for the neck stem, compute
+	# the motor angles (in radians) for the left and right motors.
+	# The left and right motor angles are placed in self.theta_l and
+	# self.theta_r
+	def inverse_kinematics(self, theta, phi) :
+		cf = cos(phi)
+		sf = sin(phi)
+
+		ct = cos(theta)
+		st = sin(theta)
+
+		# Rotate C by psi
+		psi = - atan2 (ct * sf, cf)
+		cp = cos(psi)
+		sp = sin(psi)
+		cx = cp * self.cx0 - sp * self.cy0
+		cy = sp * self.cx0 + cp * self.cy0
+		cz = self.cz0
+
+		# Rotate C by theta
+		cpx = ct * cx + st * cz
+		cpy = cy
+		cpz = -st * cx + ct * cz
+
+		# Rotate C by phi
+		self.cx = cf * cpx - sf* cpy
+		self.cy = sf * cpx + cf* cpy
+		self.cz = cpz
+
+		# Rotate F by psi
+		fx = cp * self.fx0 - sp * self.fy0
+		fy = sp * self.fx0 + cp * self.fy0
+		fz = self.fz0
+
+		# Rotate F by theta
+		fpx = ct * fx + st * fz
+		fpy = fy
+		fpz = -st * fx + ct * fz
+
+		# Rotate F by phi
+		self.fx = cf * fpx - sf * fpy
+		self.fy = sf * fpx + cf * fpy
+		self.fz = fpz
+
+		# Left and right motor angles
+		self.theta_l = self.langle()
+		self.theta_r = self.rangle()
+
+		# Double-check, using Newton's method
+		the_l = newton(self.lmoto)
+		the_r = newton(self.rmoto)
+		if abs(self.theta_l - the_l) > 1.0e-10:
+			raise ArithmeticError("Miscalculation of left motor angle!")
+		if abs(self.theta_r - the_r) > 1.0e-10:
+			raise ArithmeticError("Miscalculation of right motor angle!")
+
+
+# The lower neck linkage
+class lower_neck(neck_linkage):
+
+	# Initialization: mostly just setting of sizes of the actual
+	# lower neck geometry.
+	def __init__(self):
+
+		# Lengths of important dimensions
+		# per Davide Recchia, taken from CAD drawing
+		self.loa = 12.65
+
+		# per Davide Recchia, taken from CAD drawing
+		self.lab = 38.27
+
+		# per Davide Recchia, taken from CAD drawing
+		self.lbc = 47.68
+		self.lbf = self.lbc
+
+		# per Davide Recchia, taken from CAD drawing
+		self.lcd = 50.0
+		self.lfg = self.lcd
+
+		# Length of the motor arms.
+		# 13 from GST0025_HornNeckDynamixel drawing
+		self.lde = 13.0
+		self.lgh = self.lde
+
+		# Location of the two motors
+		# per Davide Recchia, taken from CAD drawing
+		self.hx = 40.0
+		self.hy = 34.2
+		self.hz = -57.35
+
+		self.ex = self.hx
+		self.ey = -self.hy
+		self.ez = self.hz
+
+		# Neutral location of C and F.
+		self.cx0 = self.lab
+		self.cy0 = -self.lbc
+		self.cz0 = -self.loa
+
+		self.fx0 = self.lab
+		self.fy0 = self.lbf
+		self.fz0 = -self.loa
+
+		# Current positions of C and F
+		self.cx = self.cx0
+		self.cy = self.cy0
+		self.cz = self.cz0
+
+		self.fx = self.fx0
+		self.fy = self.fy0
+		self.fz = self.fz0
+
+		# Motor neutral position
+		self.theta_r = 0.0
+		self.theta_l = 0.0
+
+# The upper neck linkage
+class upper_neck(neck_linkage):
+
+	# Initialization: mostly just setting of sizes of the actual
+	# upper neck geometry.
+	def __init__(self):
+
+		# Lengths of important dimensions
+		# per Davide Recchia, taken from CAD drawing
+		self.loa = -1.0
+
+		# per Davide Recchia, taken from CAD drawing
+		self.lab = 25.0
+
+		# per Davide Recchia, taken from CAD drawing
+		self.lbc = 35.15
+		self.lbf = self.lbc
+
+		# per Davide Recchia, taken from CAD drawing
+		self.lcd = 57.71
+		self.lfg = self.lcd
+
+		# Length of the motor arms.
+		self.lde = 16.0
+		self.lgh = self.lde
+
+		# Location of the two motors
+		self.hx = 25.0
+		self.hy = 19.85
+		self.hz = -56.71
+
+		self.ex = self.hx
+		self.ey = -self.hy
+		self.ez = self.hz
+
+		# Neutral location of C and F.
+		self.cx0 = self.lab
+		self.cy0 = -self.lbc
+		self.cz0 = -self.loa
+
+		self.fx0 = self.lab
+		self.fy0 = self.lbf
+		self.fz0 = -self.loa
+
+		# Current positions of C and F
+		self.cx = self.cx0
+		self.cy = self.cy0
+		self.cz = self.cz0
+
+		self.fx = self.fx0
+		self.fy = self.fy0
+		self.fz = self.fz0
+
+		# Motor neutral position
+		self.theta_r = 0.0
+		self.theta_l = 0.0
+
+def main():
+
+	if len(sys.argv) < 3:
+		print ("Usage: neck-kine <theta> <phi>")
+		return 1
+
+	theta = float(sys.argv[1])
+	phi = float(sys.argv[2])
+
+	lon = lower_neck()
+	upn = upper_neck()
+	lon.inverse_kinematics(theta, phi)
+	upn.inverse_kinematics(theta, phi)
+	print ("Input theta=", theta, " phi=", phi)
+	print ("Lower Motor angles", lon.theta_l, lon.theta_r)
+	print ("Upper motor angles", upn.theta_l, upn.theta_r)
+
+
+	thetas = [0.01*i for i in range(1,53)]
+	phis = [0.1*i for i in range(-15,15)]
+	for theta in thetas :
+		for phi in phis :
+			try:
+				lon.inverse_kinematics(theta, phi)
+			except OverflowError:
+				print ("Lower jam at theta=", theta, phi)
+
+			try:
+				upn.inverse_kinematics(theta, phi)
+			except OverflowError:
+				print ("Upper jam at theta=", theta, phi)
+
+#			# print ("Input theta=", theta, " phi=", phi)
+#			# print ("Motor angles", lon.theta_l, lon.theta_r)
+
+main()

--- a/test/neck-example.yaml
+++ b/test/neck-example.yaml
@@ -14,6 +14,8 @@
 # or alternately:
 # 5) rosservice call neck_pau_mux/select /cmd_neck_pau
 # 6) rosrun basic_head_api head_ctrl.py
+#
+# Then
 # 7) rostopic pub --once /point_head basic_head_api/PointHead '{yaw: 0.1, pitch:0.2, roll:0.3}' 
 #
 # Verify operation:
@@ -27,109 +29,111 @@
 # Shakes yaw the head side to side, changing the Y and Z cosines
 
 pau2motors:
-    # --- topics to be publsihed: one per motor
+    # --- topics to be published: one per motor
     topics:
         neck_pau: Upper-Gimbal-L;Upper-Gimbal-R;Lower-Gimbal-L;Lower-Gimbal-R;Neck-Rotation
-    motors:
-      # ---Neck---
 
-      - name: Upper-Gimbal-L
-        topic: Upper_Gimbal_L
-        labelleft: Upper-Gimbal-L
-        default: 0
-        min: -0.798
-        max: 1.917
-        sort_no: 29
-        group: Neck
-        hardware: dynamixel
-        pau:
-          parser:
-            name: getproperty
-            property: m_headRotation
-          function:
-            - name: quaternion2euler
-              axis: x
-            - name: linear
-              scale: -1.3
-              translate: -0.1
 
-      - name: Upper-Gimbal-R
-        topic: Upper_Gimbal_R
-        labelleft: Upper-Gimbal-R
-        default: 0
-        min: -2.086
-        max: 0.813
-        sort_no: 30
-        group: Neck
-        hardware: dynamixel
-        pau:
-          parser:
-            name: getproperty
-            property: m_headRotation
-          function:
-            - name: quaternion2euler
-              axis: x
-            - name: linear
-              scale: 1.3
-              translate: 0.1
+motors:
+  # ---Neck---
 
-      - name: Lower-Gimbal-L
-        topic: Lower_Gimbal_L
-        labelleft: Lower-Gimbal-L
-        default: 0
-        min: -1.246
-        max: 0.595
-        sort_no: 31
-        group: Neck
-        hardware: dynamixel
-        pau:
-          parser:
-            name: getproperty
-            property: m_headRotation
-          function:
-            - name: quaternion2euler
-              axis: x
-            - name: linear
-              scale: -1.5
-              translate: 0
+  - name: Upper-Gimbal-L
+    topic: Upper_Gimbal_L
+    labelleft: Upper-Gimbal-L
+    default: 0
+    min: -0.798
+    max: 1.917
+    sort_no: 29
+    group: Neck
+    hardware: dynamixel
+    pau:
+      parser:
+        name: getproperty
+        property: m_headRotation
+      function:
+        - name: quaternion2euler
+          axis: x
+        - name: linear
+          scale: -1.3
+          translate: -0.1
 
-      - name: Lower-Gimbal-R
-        topic: Lower_Gimbal_R
-        labelleft: Lower-Gimbal-R
-        default: 0
-        min: -0.506
-        max: 1.485
-        sort_no: 32
-        group: Neck
-        hardware: dynamixel
-        pau:
-          parser:
-            name: getproperty
-            property: m_headRotation
-          function:
-            - name: quaternion2euler
-              axis: x
-            - name: linear
-              scale: 1.5
-              translate: 0
+  - name: Upper-Gimbal-R
+    topic: Upper_Gimbal_R
+    labelleft: Upper-Gimbal-R
+    default: 0
+    min: -2.086
+    max: 0.813
+    sort_no: 30
+    group: Neck
+    hardware: dynamixel
+    pau:
+      parser:
+        name: getproperty
+        property: m_headRotation
+      function:
+        - name: quaternion2euler
+          axis: x
+        - name: linear
+          scale: 1.3
+          translate: 0.1
 
-      - name: Neck-Rotation
-        topic: Neck_Rotation
-        labelleft: Neck-Rotation
-        default: 0
-        min: -1.325
-        max: 1.282
-        sort_no: 33
-        group: Neck
-        hardware: dynamixel
-        pau:
-          parser:
-            name: getproperty
-            property: m_headRotation
-          function:
-            - name: quaternion2euler
-              axis: z
-            - name: linear
-              scale: -2.0
-              translate: 0
+  - name: Lower-Gimbal-L
+    topic: Lower_Gimbal_L
+    labelleft: Lower-Gimbal-L
+    default: 0
+    min: -1.246
+    max: 0.595
+    sort_no: 31
+    group: Neck
+    hardware: dynamixel
+    pau:
+      parser:
+        name: getproperty
+        property: m_headRotation
+      function:
+        - name: quaternion2euler
+          axis: x
+        - name: linear
+          scale: -1.5
+          translate: 0
+
+  - name: Lower-Gimbal-R
+    topic: Lower_Gimbal_R
+    labelleft: Lower-Gimbal-R
+    default: 0
+    min: -0.506
+    max: 1.485
+    sort_no: 32
+    group: Neck
+    hardware: dynamixel
+    pau:
+      parser:
+        name: getproperty
+        property: m_headRotation
+      function:
+        - name: quaternion2euler
+          axis: x
+        - name: linear
+          scale: 1.5
+          translate: 0
+
+  - name: Neck-Rotation
+    topic: Neck_Rotation
+    labelleft: Neck-Rotation
+    default: 0
+    min: -1.325
+    max: 1.282
+    sort_no: 33
+    group: Neck
+    hardware: dynamixel
+    pau:
+      parser:
+        name: getproperty
+        property: m_headRotation
+      function:
+        - name: quaternion2euler
+          axis: z
+        - name: linear
+          scale: -2.0
+          translate: 0
 

--- a/test/neck-example.yaml
+++ b/test/neck-example.yaml
@@ -26,106 +26,110 @@
 # Nods pitch the head back and forth changing the X cosine
 # Shakes yaw the head side to side, changing the Y and Z cosines
 
-motors:
-  # ---Neck---
+pau2motors:
+    # --- topics to be publsihed: one per motor
+    topics:
+        neck_pau: Upper-Gimbal-L;Upper-Gimbal-R;Lower-Gimbal-L;Lower-Gimbal-R;Neck-Rotation
+    motors:
+      # ---Neck---
 
-  - name: Upper-Gimbal-L
-    topic: Upper_Gimbal_L
-    labelleft: Upper-Gimbal-L
-    default: 0
-    min: -0.798
-    max: 1.917
-    sort_no: 29
-    group: Neck
-    hardware: dynamixel
-    pau:
-      parser:
-        name: getproperty
-        property: m_headRotation
-      function:
-        - name: quaternion2euler
-          axis: x
-        - name: linear
-          scale: -1.3
-          translate: -0.1
+      - name: Upper-Gimbal-L
+        topic: Upper_Gimbal_L
+        labelleft: Upper-Gimbal-L
+        default: 0
+        min: -0.798
+        max: 1.917
+        sort_no: 29
+        group: Neck
+        hardware: dynamixel
+        pau:
+          parser:
+            name: getproperty
+            property: m_headRotation
+          function:
+            - name: quaternion2euler
+              axis: x
+            - name: linear
+              scale: -1.3
+              translate: -0.1
 
-  - name: Upper-Gimbal-R
-    topic: Upper_Gimbal_R
-    labelleft: Upper-Gimbal-R
-    default: 0
-    min: -2.086
-    max: 0.813
-    sort_no: 30
-    group: Neck
-    hardware: dynamixel
-    pau:
-      parser:
-        name: getproperty
-        property: m_headRotation
-      function:
-        - name: quaternion2euler
-          axis: x
-        - name: linear
-          scale: 1.3
-          translate: 0.1
+      - name: Upper-Gimbal-R
+        topic: Upper_Gimbal_R
+        labelleft: Upper-Gimbal-R
+        default: 0
+        min: -2.086
+        max: 0.813
+        sort_no: 30
+        group: Neck
+        hardware: dynamixel
+        pau:
+          parser:
+            name: getproperty
+            property: m_headRotation
+          function:
+            - name: quaternion2euler
+              axis: x
+            - name: linear
+              scale: 1.3
+              translate: 0.1
 
-  - name: Lower-Gimbal-L
-    topic: Lower_Gimbal_L
-    labelleft: Lower-Gimbal-L
-    default: 0
-    min: -1.246
-    max: 0.595
-    sort_no: 31
-    group: Neck
-    hardware: dynamixel
-    pau:
-      parser:
-        name: getproperty
-        property: m_headRotation
-      function:
-        - name: quaternion2euler
-          axis: x
-        - name: linear
-          scale: -1.5
-          translate: 0
+      - name: Lower-Gimbal-L
+        topic: Lower_Gimbal_L
+        labelleft: Lower-Gimbal-L
+        default: 0
+        min: -1.246
+        max: 0.595
+        sort_no: 31
+        group: Neck
+        hardware: dynamixel
+        pau:
+          parser:
+            name: getproperty
+            property: m_headRotation
+          function:
+            - name: quaternion2euler
+              axis: x
+            - name: linear
+              scale: -1.5
+              translate: 0
 
-  - name: Lower-Gimbal-R
-    topic: Lower_Gimbal_R
-    labelleft: Lower-Gimbal-R
-    default: 0
-    min: -0.506
-    max: 1.485
-    sort_no: 32
-    group: Neck
-    hardware: dynamixel
-    pau:
-      parser:
-        name: getproperty
-        property: m_headRotation
-      function:
-        - name: quaternion2euler
-          axis: x
-        - name: linear
-          scale: 1.5
-          translate: 0
+      - name: Lower-Gimbal-R
+        topic: Lower_Gimbal_R
+        labelleft: Lower-Gimbal-R
+        default: 0
+        min: -0.506
+        max: 1.485
+        sort_no: 32
+        group: Neck
+        hardware: dynamixel
+        pau:
+          parser:
+            name: getproperty
+            property: m_headRotation
+          function:
+            - name: quaternion2euler
+              axis: x
+            - name: linear
+              scale: 1.5
+              translate: 0
 
-  - name: Neck-Rotation
-    topic: Neck_Rotation
-    labelleft: Neck-Rotation
-    default: 0
-    min: -1.325
-    max: 1.282
-    sort_no: 33
-    group: Neck
-    hardware: dynamixel
-    pau:
-      parser:
-        name: getproperty
-        property: m_headRotation
-      function:
-        - name: quaternion2euler
-          axis: z
-        - name: linear
-          scale: -2.0
-          translate: 0
+      - name: Neck-Rotation
+        topic: Neck_Rotation
+        labelleft: Neck-Rotation
+        default: 0
+        min: -1.325
+        max: 1.282
+        sort_no: 33
+        group: Neck
+        hardware: dynamixel
+        pau:
+          parser:
+            name: getproperty
+            property: m_headRotation
+          function:
+            - name: quaternion2euler
+              axis: z
+            - name: linear
+              scale: -2.0
+              translate: 0
 

--- a/test/neck-example.yaml
+++ b/test/neck-example.yaml
@@ -51,11 +51,8 @@ motors:
         name: getproperty
         property: m_headRotation
       function:
-        - name: quaternion2euler
-          axis: x
-        - name: linear
-          scale: -1.3
-          translate: -0.1
+        - name: quaternion2neck
+          axis: ul
 
   - name: Upper-Gimbal-R
     topic: Upper_Gimbal_R

--- a/test/neck-example.yaml
+++ b/test/neck-example.yaml
@@ -58,7 +58,7 @@ motors:
         property: m_headRotation
       function:
         - name: quaternion2neck
-          axis: ul
+          axis: upleft
 
   - name: Upper-Gimbal-R
     topic: Upper_Gimbal_R
@@ -74,11 +74,8 @@ motors:
         name: getproperty
         property: m_headRotation
       function:
-        - name: quaternion2euler
-          axis: x
-        - name: linear
-          scale: 1.3
-          translate: 0.1
+        - name: quaternion2neck
+          axis: upright
 
   - name: Lower-Gimbal-L
     topic: Lower_Gimbal_L
@@ -97,7 +94,7 @@ motors:
         - name: quaternion2euler
           axis: x
         - name: linear
-          scale: -1.5
+          scale: 0
           translate: 0
 
   - name: Lower-Gimbal-R
@@ -117,7 +114,7 @@ motors:
         - name: quaternion2euler
           axis: x
         - name: linear
-          scale: 1.5
+          scale: 0
           translate: 0
 
   - name: Neck-Rotation

--- a/test/neck-example.yaml
+++ b/test/neck-example.yaml
@@ -7,6 +7,9 @@
 # 1) restart roscore
 # 2) rosparam load pau2motors/test/neck-example.yaml
 # 3) rosrun pau2motors pau2motors_node.py
+#    This publishes the /foo/Lower_Gimbal_L_controller/command etc
+#    and the /foo/neck_pau topics
+#
 # 4) rosrun topic_tools mux /foo/neck_pau  cmd_neck_pau /blender_api/get_pau mux:=neck_pau_mux
 # 5) rosservice call neck_pau_mux/select /blender_api/get_pau
 # 6) blender -y Eva.blend -P autostart.py
@@ -17,6 +20,9 @@
 # 7) rostopic pub --once /point_head basic_head_api/PointHead '{yaw: 0.1, pitch:0.2, roll:0.3}' 
 #
 # Verify operation:
+# Make her look in different directions:
+# The external coord system is x==straight-ahead; y==body-left, z==up
+# rostopic pub --once /blender_api/set_face_target blender_api_msgs/Target '{x: 1.0, y: -0.3 , z: -0.3}'
 # rostopic echo /foo/Lower_Gimbal_L_controller/command
 # rostopic echo /foo/Lower_Gimbal_R_controller/command
 # rostopic echo /foo/Upper_Gimbal_L_controller/command

--- a/test/neck-example.yaml
+++ b/test/neck-example.yaml
@@ -11,17 +11,17 @@
 # 5) rosservice call neck_pau_mux/select /blender_api/get_pau
 # 6) blender -y Eva.blend -P autostart.py
 #
-# or alternately:
+# For the older robots, use this:
 # 5) rosservice call neck_pau_mux/select /cmd_neck_pau
 # 6) rosrun basic_head_api head_ctrl.py
-#
-# Then
 # 7) rostopic pub --once /point_head basic_head_api/PointHead '{yaw: 0.1, pitch:0.2, roll:0.3}' 
 #
 # Verify operation:
-# rostopic echo /foo/left_motor
-# rostopic echo /foo/right_motor
-# rostopic echo /foo/axis_motor
+# rostopic echo /foo/Lower_Gimbal_L_controller/command
+# rostopic echo /foo/Lower_Gimbal_R_controller/command
+# rostopic echo /foo/Upper_Gimbal_L_controller/command
+# rostopic echo /foo/Upper_Gimbal_R_controller/command
+# rostopic echo /foo/Neck_Rotation_controller/command
 #
 # Coordinate conventions:
 # Curent Eva blender model uses:

--- a/test/neck-example.yaml
+++ b/test/neck-example.yaml
@@ -128,8 +128,8 @@ motors:
         name: getproperty
         property: m_headRotation
       function:
-        - name: quaternion2euler
-          axis: z
+        - name: quaternion2neck
+          axis: yaw
         - name: linear
           scale: -2.0
           translate: 0

--- a/test/neck-example.yaml
+++ b/test/neck-example.yaml
@@ -26,61 +26,106 @@
 # Nods pitch the head back and forth changing the X cosine
 # Shakes yaw the head side to side, changing the Y and Z cosines
 
-pau2motors:
-    # --- topics to be publsihed: one per motor
-    topics:
-        neck_pau: neck_axis;neck_left;neck_right
+motors:
+  # ---Neck---
 
-    motors:
-      # ---Neck---
-      neck_axis:
-        binding:
-          parser:
-            name: getproperty
-            property: m_headRotation
-          function:
-            - name: quaternion2euler
-              axis: z
-            - name: linear
-              scale: -2.92
-              translate: 0
-          hardware:
-            name: dynamixel
-            topic: axis
-        min: -1.57
-        max: 1.57
+  - name: Upper-Gimbal-L
+    topic: Upper_Gimbal_L
+    labelleft: Upper-Gimbal-L
+    default: 0
+    min: -0.798
+    max: 1.917
+    sort_no: 29
+    group: Neck
+    hardware: dynamixel
+    pau:
+      parser:
+        name: getproperty
+        property: m_headRotation
+      function:
+        - name: quaternion2euler
+          axis: x
+        - name: linear
+          scale: -1.3
+          translate: -0.1
 
-      neck_left:
-        binding:
-          parser:
-            name: getproperty
-            property: m_headRotation
-          function:
-            - name: quaternion2euler
-              axis: x
-            - name: linear
-              scale: 1.3
-              translate: 0
-          hardware:
-            name: dynamixel
-            topic: left_motor
-        min: -1.57
-        max: 1.57
+  - name: Upper-Gimbal-R
+    topic: Upper_Gimbal_R
+    labelleft: Upper-Gimbal-R
+    default: 0
+    min: -2.086
+    max: 0.813
+    sort_no: 30
+    group: Neck
+    hardware: dynamixel
+    pau:
+      parser:
+        name: getproperty
+        property: m_headRotation
+      function:
+        - name: quaternion2euler
+          axis: x
+        - name: linear
+          scale: 1.3
+          translate: 0.1
 
-      neck_right:
-        binding:
-          parser:
-            name: getproperty
-            property: m_headRotation
-          function:
-            - name: quaternion2euler
-              axis: x
-            - name: linear
-              scale: -1.3
-              translate: 0
-          hardware:
-            name: dynamixel
-            topic: right_motor
-        min: -1.57
-        max: 1.57
+  - name: Lower-Gimbal-L
+    topic: Lower_Gimbal_L
+    labelleft: Lower-Gimbal-L
+    default: 0
+    min: -1.246
+    max: 0.595
+    sort_no: 31
+    group: Neck
+    hardware: dynamixel
+    pau:
+      parser:
+        name: getproperty
+        property: m_headRotation
+      function:
+        - name: quaternion2euler
+          axis: x
+        - name: linear
+          scale: -1.5
+          translate: 0
+
+  - name: Lower-Gimbal-R
+    topic: Lower_Gimbal_R
+    labelleft: Lower-Gimbal-R
+    default: 0
+    min: -0.506
+    max: 1.485
+    sort_no: 32
+    group: Neck
+    hardware: dynamixel
+    pau:
+      parser:
+        name: getproperty
+        property: m_headRotation
+      function:
+        - name: quaternion2euler
+          axis: x
+        - name: linear
+          scale: 1.5
+          translate: 0
+
+  - name: Neck-Rotation
+    topic: Neck_Rotation
+    labelleft: Neck-Rotation
+    default: 0
+    min: -1.325
+    max: 1.282
+    sort_no: 33
+    group: Neck
+    hardware: dynamixel
+    pau:
+      parser:
+        name: getproperty
+        property: m_headRotation
+      function:
+        - name: quaternion2euler
+          axis: z
+        - name: linear
+          scale: -2.0
+          translate: 0
 

--- a/test/neck-example.yaml
+++ b/test/neck-example.yaml
@@ -42,6 +42,8 @@ pau2motors:
 
 motors:
   # ---Neck---
+  # XXX to-do: output values are in radians.... need to convert
+  # to motor values ...XXX
 
   - name: Upper-Gimbal-L
     topic: Upper_Gimbal_L


### PR DESCRIPTION
Install the neck kinematics code.  With an appropriate yaml file, this should correctly control the upper u-joint.  Existing behavior for older code is unchanged.